### PR TITLE
Fix AI Trip Planner preference selection colors

### DIFF
--- a/src/components/AITripModal.js
+++ b/src/components/AITripModal.js
@@ -401,7 +401,7 @@ const AITripModal = ({ isOpen, onClose, onTripCreated }) => {
                       onClick={() => togglePreference(pref.toLowerCase())}
                       className={`px-4 py-2 rounded-full text-sm transition-colors ${
                         formData.tripPreferences.includes(pref.toLowerCase())
-                          ? 'bg-primary text-white'
+                          ? 'bg-primary-600 text-white'
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                       }`}
                     >
@@ -423,7 +423,7 @@ const AITripModal = ({ isOpen, onClose, onTripCreated }) => {
                       onClick={() => setFormData({ ...formData, pacePreference: option.value })}
                       className={`p-3 rounded-lg border-2 transition-all ${
                         formData.pacePreference === option.value
-                          ? 'border-primary bg-primary-50'
+                          ? 'border-primary-600 bg-primary-50'
                           : 'border-gray-200 hover:border-gray-300'
                       }`}
                     >


### PR DESCRIPTION
Fixed white-on-white visibility issues in AI Trip Planner modal:
- Changed Trip Preferences selected state from 'bg-primary' to 'bg-primary-600'
- Changed Pace Preference border from 'border-primary' to 'border-primary-600'

These changes ensure selected preferences are visible with proper theme colors instead of appearing as white-on-white when selected.